### PR TITLE
Update zcombo-g name, identifier and description

### DIFF
--- a/config/firstalert/zcombo-g.xml
+++ b/config/firstalert/zcombo-g.xml
@@ -1,12 +1,15 @@
 <Product Revision="1"
   xmlns="https://github.com/OpenZWave/open-zwave">
   <MetaData>
-    <MetaDataItem name="Name">Battery Smoke/CO Combo Alarm</MetaDataItem>
-    <MetaDataItem name="Description">ZWave enabled, battery-powered combination smoke and carbon monoxide alarm</MetaDataItem>
+    <MetaDataItem name="Name">ZCombo-G Smoke/CO Alarm</MetaDataItem>
     <MetaDataItem name="OzwInfoPage">http://www.openzwave.com/device-database/0138:0003:0001</MetaDataItem>
     <MetaDataItem name="ProductPage">https://products.z-wavealliance.org/products/3886</MetaDataItem>
     <MetaDataItem name="ProductPic">images/firstalert/zcombo-g.png</MetaDataItem>
     <MetaDataItem name="ProductManual">https://products.z-wavealliance.org/ProductManual/File?folder=&amp;filename=product_documents/3886/User_Manual_M08-0456-173833_D2.pdf</MetaDataItem>
+    <MetaDataItem name="Description">The Z-Wave Smoke/CO alarm can be implemented in residential and institutional applications. Installation settings include sleeping areas within hospitals, hotels, motels, dormitories and other multi-family dwellings that are defined in standard NFPA 101. The First Alert ZCOMBO-G Smoke and Carbon Monoxide Detector has been fully tested and complies with UL217, UL2034, CSFM, NFPA 720, NFPA 101 and other agencies that model their codes after the above agencies. The combination alarm meets building codes that require the use of a battery operated Z-Wave wireless Smoke and CO detector. This First Alert Z-Wave Combination Alarm includes silence features and meets the model building codes published by the ICC.
+    The First Alert Z-Wave Combo Alarm includes: an insect screened photoelectric smoke sensing chamber, electrochemical carbon monoxide sensor, 85dB horn, supervised 3V (2 AA batteries) power supply, full function test switch and a silence feature.
+    The First Alert Z-Wave Enabled Battery Smoke &amp; Carbon Monoxide Combo Alarm includes a battery drawer that prevents battery removal and tamper resistant locking pins that lock the alarm to the mounting bracket. This First Alert Combination Alarm is an ideal fit for any number of applications that include apartments, dormitories, and hotels. Designed for wall or ceiling mounting, this alarm includes all of the required mounting anchors and screws needed for easy installation.
+    </MetaDataItem>
     <MetaDataItem name="WakeupDescription">To manual wake-up the device, slide the battery door open wait for ~5 seconds and then slide the battery drawer closed. Upon power-up, the device will send the wake-up notification.</MetaDataItem>
     <MetaDataItem name="InclusionDescription">1. Slide battery door open.
 2. Insert batteries checking the correct orientation.
@@ -20,7 +23,7 @@ Please use this procedure only when the network primary controller is missing or
     </MetaDataItem>
     <MetaDataItem id="0003" name="ZWProductPage" type="0001">https://products.z-wavealliance.org/products/3886/</MetaDataItem>
     <MetaDataItem id="0003" name="FrequencyName" type="0001">U.S. / Canada / Mexico</MetaDataItem>
-    <MetaDataItem id="0003" name="Identifier" type="0001">ZCOMBO-G</MetaDataItem>
+    <MetaDataItem id="0003" name="Identifier" type="0001">ZCOMBO</MetaDataItem>
     <ChangeLog>
       <Entry author="Richard Tallent - richard@tallent.us" date="11 Oct 2020" revision="1">Copy from ZCOMBO, update based on Z-Wave Alliance Database - https://products.z-wavealliance.org/products/3886/xml</Entry>
     </ChangeLog>

--- a/config/manufacturer_specific.xml
+++ b/config/manufacturer_specific.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ManufacturerSpecificData Revision="122"
+<ManufacturerSpecificData Revision="123"
   xmlns="https://github.com/OpenZWave/open-zwave">
   <Manufacturer id="0028" name="2B Electronics"></Manufacturer>
   <Manufacturer id="0098" name="2GIG Technologies">
@@ -749,7 +749,7 @@
   <Manufacturer id="0295" name="fifthplay nv"></Manufacturer>
   <Manufacturer id="0138" name="First Alert (BRK Brands Inc)">
     <Product config="firstalert/zcombo.xml" id="0002" name="ZCombo Smoke and Carbon Monoxide Detector" type="0001"/>
-    <Product config="firstalert/zcombo-g.xml" id="0003" name="ZCombo-G Battery Smoke/CO Combo Alarm" type="0001"/>
+    <Product config="firstalert/zcombo-g.xml" id="0003" name="ZCombo-G Smoke/CO Alarm" type="0001"/>
   </Manufacturer>
   <Manufacturer id="002c" name="Flex Automation"></Manufacturer>
   <Manufacturer id="004F" name="Flex Automation"></Manufacturer>

--- a/cpp/build/testconfigversions.cfg
+++ b/cpp/build/testconfigversions.cfg
@@ -1101,7 +1101,7 @@
                                               },
                'config/firstalert/zcombo-g.xml' => {
                                                      'Revision' => 1,
-                                                     'md5' => '8ab9b6882ff1e1106c3f3aa30330abda9aec89b4b41ea0927d695c95b3768c39bebdc67ecd0ca40374b8edd6b4b6be1a134a23221e8703cce7969fccfc52b70e'
+                                                     'md5' => '3aafd7c7283dde9c093a55c0c6e0cc0c8f221e9b06f647cc151b97a4bd4296c2715e89d9c62886d275f213376e2e3052a23ce05ed027a181f054459fdef0e3cb'
                                                    },
                'config/firstalert/zcombo.xml' => {
                                                    'Revision' => 2,
@@ -1856,8 +1856,8 @@
                                                    'md5' => '4d34aeaaea917c229bedbb737e4de1550b2d7db5f9e61566a1c0a39966b6442d381d01f93714e12aae1404797d36854274cc4063dd7424b00d27da238b17a36a'
                                                  },
                'config/manufacturer_specific.xml' => {
-                                                       'Revision' => 122,
-                                                       'md5' => '0f6a2e8dc19fe68ee29dded152640260101b78ca5c2ab8de8f37ce929045a4ceeb9a62cb633db19a2ec94360ee0e225b760c25abd7001732bced552c77d916b4'
+                                                       'Revision' => 123,
+                                                       'md5' => '099f2c000c1016574b0d6c512b3b44797c7b22bda46c7b68f35a500f69964900a9861f76106a1e23e7c2b8e8226f0b756764cc9c60bb1944c53df6d4b81f32f2'
                                                      },
                'config/mcohome/a8-9.xml' => {
                                               'Revision' => 1,


### PR DESCRIPTION
@richardtallent This is an update to the ZCombo-G as discussed on https://github.com/OpenZWave/open-zwave/pull/2420 to align name, identifier and description with first alert info.
I also bumped up manufacturer_specific.xml version because origin is already on 122.
